### PR TITLE
User details claims

### DIFF
--- a/Blackbaud.Addin.TokenAuthentication.Tests/UserIdentityTokenTests.cs
+++ b/Blackbaud.Addin.TokenAuthentication.Tests/UserIdentityTokenTests.cs
@@ -19,6 +19,9 @@ namespace Blackbaud.Addin.TokenAuthentication.Tests
         private const string TEST_AUD = "f4414c4d-7a29-4249-82b4-4b10a8b4719f";
         private const string TEST_USERID = "9d874c83-cd07-4690-ab6d-ad9551dbacf4";
         private const string TEST_ENVID = "p-Q2caBopqjEisbiLbtjEoMh";
+        private const string TEST_EMAIL = "test_user@example.com";
+        private const string TEST_FAMILY_NAME = "User";
+        private const string TEST_GIVEN_NAME = "Test";
 
         [TestMethod]
         [Description("Tests that the constructor is successful.")]
@@ -191,7 +194,7 @@ namespace Blackbaud.Addin.TokenAuthentication.Tests
         }
 
         [TestMethod]
-        [Description("If the token is valid, the userId and environmentId are returned.")]
+        [Description("If the token is valid, the userId, email, familyName, givenName, and environmentId are returned.")]
         public async Task UserIdentityToken_ValidToken()
         {
             var mockCache = GetMockCache();
@@ -206,6 +209,9 @@ namespace Blackbaud.Addin.TokenAuthentication.Tests
                 var identity = new ClaimsIdentity("RandomValue");
                 identity.AddClaim(new Claim(ClaimTypes.NameIdentifier, TEST_USERID));
                 identity.AddClaim(new Claim("environment_id", TEST_ENVID));
+                identity.AddClaim(new Claim(ClaimTypes.Email, TEST_EMAIL));
+                identity.AddClaim(new Claim(ClaimTypes.Surname, TEST_FAMILY_NAME));
+                identity.AddClaim(new Claim(ClaimTypes.GivenName, TEST_GIVEN_NAME));
 
                 result.AddIdentity(identity);
                 return result;
@@ -215,6 +221,9 @@ namespace Blackbaud.Addin.TokenAuthentication.Tests
 
             Assert.AreEqual(mockToken.Object.UserId, TEST_USERID, true);
             Assert.AreEqual(mockToken.Object.EnvironmentId, TEST_ENVID, true);
+            Assert.AreEqual(mockToken.Object.Email, TEST_EMAIL, true);
+            Assert.AreEqual(mockToken.Object.FamilyName, TEST_FAMILY_NAME, true);
+            Assert.AreEqual(mockToken.Object.GivenName, TEST_GIVEN_NAME, true);
 
             mockCache.Verify(o => o.Refresh(), Times.Never);
         }

--- a/Blackbaud.Addin.TokenAuthentication/SigningKeysCache.cs
+++ b/Blackbaud.Addin.TokenAuthentication/SigningKeysCache.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Net;
 using System.Net.Http;
 using System.Security.Cryptography.X509Certificates;
 using System.Threading.Tasks;
@@ -22,6 +23,7 @@ namespace Blackbaud.Addin.TokenAuthentication
         /// </summary>
         internal SigningKeysCache()
         {
+            ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
         }
 
         /// <summary>

--- a/Blackbaud.Addin.TokenAuthentication/SigningKeysCache.cs
+++ b/Blackbaud.Addin.TokenAuthentication/SigningKeysCache.cs
@@ -23,7 +23,6 @@ namespace Blackbaud.Addin.TokenAuthentication
         /// </summary>
         internal SigningKeysCache()
         {
-            ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
         }
 
         /// <summary>

--- a/Blackbaud.Addin.TokenAuthentication/SigningKeysCache.cs
+++ b/Blackbaud.Addin.TokenAuthentication/SigningKeysCache.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Net;
 using System.Net.Http;
 using System.Security.Cryptography.X509Certificates;
 using System.Threading.Tasks;

--- a/Blackbaud.Addin.TokenAuthentication/UserIdentityToken.cs
+++ b/Blackbaud.Addin.TokenAuthentication/UserIdentityToken.cs
@@ -66,6 +66,21 @@ namespace Blackbaud.Addin.TokenAuthentication
         public string UserId { get; private set; }
 
         /// <summary>
+        /// The user email address
+        /// </summary>
+        public string Email { get; private set; }
+
+        /// <summary>
+        /// The user last name
+        /// </summary>
+        public string FamilyName { get; private set; }
+
+        /// <summary>
+        /// The user first name
+        /// </summary>
+        public string GivenName { get; private set; }
+
+        /// <summary>
         /// The environment identifier
         /// </summary>
         public string EnvironmentId { get; private set; }
@@ -143,6 +158,9 @@ namespace Blackbaud.Addin.TokenAuthentication
                     var cp = ValidateToken(token, validationparams);
                     var userId = GetClaimValue(ClaimTypes.NameIdentifier, cp.Claims);
                     var envId = GetClaimValue("environment_id", cp.Claims);
+                    var email = GetClaimValue(ClaimTypes.Email, cp.Claims);
+                    var familyName = GetClaimValue(ClaimTypes.Surname, cp.Claims);
+                    var givenName = GetClaimValue(ClaimTypes.GivenName, cp.Claims);
 
                     // if no userId was found, throw an exception
                     if (string.IsNullOrEmpty(userId))
@@ -156,8 +174,30 @@ namespace Blackbaud.Addin.TokenAuthentication
                         throw new InvalidTokenFormatException();
                     }
 
+                    // if no email was found, throw an exception
+                    if (string.IsNullOrEmpty(email))
+                    {
+                        throw new InvalidTokenFormatException();
+                    }
+
+                    // if no familyName was found, throw an exception
+                    if (string.IsNullOrEmpty(familyName))
+                    {
+                        throw new InvalidTokenFormatException();
+                    }
+
+                    // if no givenName was found, throw an exception
+                    if (string.IsNullOrEmpty(givenName))
+                    {
+                        throw new InvalidTokenFormatException();
+                    }
+
+
                     this.UserId = userId;
                     this.EnvironmentId = envId;
+                    this.Email = email;
+                    this.FamilyName = familyName;
+                    this.GivenName = givenName;
                     return;
                 }
                 catch (SecurityTokenInvalidAudienceException e1)

--- a/README.md
+++ b/README.md
@@ -50,8 +50,17 @@ try
 
     // if valid, the UserId property contains the Blackbaud user's ID
     var userId = uit.UserId;
+    
+    // if valid, the Email property contains the Blackbaud user's email address
+    var email = uit.Email;
+    
+    // if valid, the FamilyName property contains the Blackbaud user's last name
+    var familyName = uit.FamilyName;
+    
+    // if valid, the GivenName property contains the Blackbaud user's first name
+    var givenName = uit.GivenName;
 
-	//if valid, the EnvironmentId property contains the environment ID
+    //if valid, the EnvironmentId property contains the environment ID
     var envId = uit.EnvironmentId;
 }
 catch (TokenValidationException ex)


### PR DESCRIPTION
Parse out user details from UIT and populate UserIdentityToken object.

Tested these changes in a standalone test app.

I have an email flagged stating we should add the `ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12` to support TLS 1.2. 