### PR TITLE
Add calls to ConfigureAwait(false) to async/await functions to avoid deadlocks

### DIFF
--- a/Blackbaud.Addin.TokenAuthentication/SigningKeysCache.cs
+++ b/Blackbaud.Addin.TokenAuthentication/SigningKeysCache.cs
@@ -74,14 +74,14 @@ namespace Blackbaud.Addin.TokenAuthentication
             using (var client = new HttpClient())
             {
                 // Process OpenIdConfig
-                var config = await client.GetStringAsync(_openIdConfigUrl);
+                var config = await client.GetStringAsync(_openIdConfigUrl).ConfigureAwait(false);
                 var c = JObject.Parse(config);
 
                 var issuer = c.Value<string>("issuer");
                 var jwks_uri = c.Value<string>("jwks_uri");
 
                 // Process JwksUri
-                var jwksResponse = await client.GetStringAsync(jwks_uri);
+                var jwksResponse = await client.GetStringAsync(jwks_uri).ConfigureAwait(false);
                 var jwks = JObject.Parse(jwksResponse);
                 var keys = jwks.Value<JArray>("keys");
 

--- a/Blackbaud.Addin.TokenAuthentication/UserIdentityToken.cs
+++ b/Blackbaud.Addin.TokenAuthentication/UserIdentityToken.cs
@@ -52,7 +52,7 @@ namespace Blackbaud.Addin.TokenAuthentication
         public static async Task<UserIdentityToken> ParseAsync(string token, Guid applicationId)
         {
             var uit = new UserIdentityToken(SigningKeysCache.Instance);
-            await uit.ValidateTokenAsync(token, applicationId);
+            await uit.ValidateTokenAsync(token, applicationId).ConfigureAwait(false);
             return uit;
         }
 
@@ -126,7 +126,7 @@ namespace Blackbaud.Addin.TokenAuthentication
             var cacheKey = t.Header.Kid ?? t.Header.X5t ?? string.Empty;
             if (!_signingKeysCache.Certificates.ContainsKey(cacheKey) || _signingKeysCache.RefreshNeeded())
             {
-                await _signingKeysCache.Refresh();
+                await _signingKeysCache.Refresh().ConfigureAwait(false);
 
                 // If it still doesn't contain the key, then enter a null value to avoid re-checking each time.
                 if (!_signingKeysCache.Certificates.ContainsKey(cacheKey))


### PR DESCRIPTION
From [https://devblogs.microsoft.com/dotnet/configureawait-faq/](https://devblogs.microsoft.com/dotnet/configureawait-faq/):

> if you’re writing general-purpose library code, use ConfigureAwait(false)

Without calls to ConfigureAwait(false), any code that tries to block on the `ParseAsyc` method (for example) can end up deadlocked.